### PR TITLE
Fix EventEmitter import

### DIFF
--- a/nextnative/navigationEvents.js
+++ b/nextnative/navigationEvents.js
@@ -1,5 +1,5 @@
 import { AsyncStorage } from "react-native";
-import EventEmitter from "EventEmitter";
+import { EventEmitter } from "events";
 
 const navigationEvents = new EventEmitter();
 


### PR DESCRIPTION
## Summary
- fix EventEmitter import so navigation events work on Node

## Testing
- `npm test --silent` *(fails: Cannot find module `jest/bin/jest.js`)*